### PR TITLE
fix encoding to be utf-8 in render_local_doc html

### DIFF
--- a/src/opencv_pg/docs/doc_writer.py
+++ b/src/opencv_pg/docs/doc_writer.py
@@ -32,7 +32,7 @@ def render_local_doc(folder, doc_fname):
         html = template.render(error=f"Template: {doc_fname} not found :(")
 
     path = folder.joinpath(doc_fname)
-    with open(path, "w") as fout:
+    with open(path, "w", encoding="utf-8") as fout:
         fout.write(html)
         log.debug("Wrote Doc: %s", path)
 


### PR DESCRIPTION
FIX UnicodeEncodeError: 'charmap' codec can't encode character '\u2192' in position 726: character maps to <undefined>